### PR TITLE
Updates `ApiClient` to use constants

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Client;
 class ApiClient extends Client {
   public static function factory($config = array()) {
     if (empty($config['token'])) {
-      throw new Exceptions\MissingClientTokenException('Missing required API token.');
+      throw new Exception\MissingClientTokenException('Missing required API token.');
     }
 
     $defaults = array(

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -5,19 +5,24 @@ namespace Envato;
 use GuzzleHttp\Client;
 
 class ApiClient extends Client {
+  const VERSION    = '0.1';
+  const USER_AGENT = 'Envato PHP SDK/' . self::VERSION;
+  const BASE_URI   = 'https://api.envato.com';
+
   public static function factory($config = array()) {
     if (empty($config['token'])) {
       throw new Exception\MissingClientTokenException('Missing required API token.');
     }
 
     $defaults = array(
+      'base_uri' => self::BASE_URI,
       'connect_timeout' => '3',
       'timeout' => '10',
       'verify' => TRUE,
       'allow_redirects' => FALSE,
       'headers' => array(
         'Authorization' => "Bearer {$config['token']}",
-        'User-Agent' => 'Envato PHP SDK/0.1',
+        'User-Agent' => self::USER_AGENT,
       ),
     );
 
@@ -28,12 +33,12 @@ class ApiClient extends Client {
   }
 
   public function whoami() {
-    $request = $this->get('https://api.envato.com/whoami');
+    $request = $this->get('/whoami');
     return new Response\WhoAmI($request);
   }
 
   public function account() {
-    $request = $this->get('https://api.envato.com/v1/market/private/user/account.json');
+    $request = $this->get('/v1/market/private/user/account.json');
     return new Response\Account($request);
   }
 }

--- a/src/Exception/MissingClientTokenException.php
+++ b/src/Exception/MissingClientTokenException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Envato\Exceptions;
+namespace Envato\Exception;
 
 // @codingStandardsIgnoreStart
 class MissingClientTokenException extends \Exception {}

--- a/tests/ApiClientTest.php
+++ b/tests/ApiClientTest.php
@@ -11,7 +11,7 @@ final class ApiClientTest extends TestCase {
   }
 
   public function testClientApiTokenIsRequired() {
-    $this->expectException(Envato\Exceptions\MissingClientTokenException::class);
+    $this->expectException(Envato\Exception\MissingClientTokenException::class);
     ApiClient::factory(array());
   }
 


### PR DESCRIPTION
As I'm building this client out, I've only been testing this against the
public api.envato.com however internally we have other environments (and
hostnames) that we can use for testing.

If I need to test this on another hostname, it's a right royal pain to
update all the references and then do the work. Instead, I'm defining a
`base_uri` in the Guzzle options which will allow me to set a default
hostname but pass in the option when I need to override it.

```php
$client = ApiClient::factory(array(
 'token' => 'xxx',
 'base_uri' => 'someotherhost.example.com'
));
```

This commit also pulls out the user agent and version into constants too
since we don't really need those to be changing but should be updated in
one spot if/when we do decide to.