### PR TITLE
Create a `RateLimiter` for managing rate limited responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
   - travis_retry composer install --no-interaction --no-suggest
 
 script:
-  - ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests
+  - ./vendor/bin/phpunit-randomizer --order rand --bootstrap vendor/autoload.php tests
   - ./vendor/bin/phpcs --standard=phpcs.xml src/

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ classes available. These classes are a one to one mapping of the API endpoints.
 You can run the test suite using the following command:
 
 ```
-$ ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests
+$ ./vendor/bin/phpunit-randomizer --order rand --bootstrap vendor/autoload.php tests
 ```
 
 Please. Please. Please. Ensure all changes have tests. If not, there is a good
 chance untested functionality will be broken without knowing about it.
 
-This project uses PHP Codesniffer to enforce standards in CI. You can run it 
+This project uses PHP Codesniffer to enforce standards in CI. You can run it
 locally using:
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+        "fiunchinho/phpunit-randomizer": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "6.*",

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -3,6 +3,12 @@
 namespace Envato;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Handler\CurlHandler;
+use Envato\Middleware\RateLimiter;
 
 class ApiClient extends Client {
   const VERSION    = '0.1';
@@ -11,10 +17,40 @@ class ApiClient extends Client {
 
   public static function factory($config = array()) {
     if (empty($config['token'])) {
-      throw new Exception\MissingClientTokenException('Missing required API token.');
+      throw new Exception\MissingClientTokenException;
     }
 
+    $rate_limiter = new RateLimiter();
+    $stack = new HandlerStack();
+    $stack->setHandler(new CurlHandler());
+
+    $stack->push(
+      Middleware::mapRequest(
+        function (RequestInterface $request) use ($rate_limiter) {
+          if ($rate_limiter->isThrottled()) {
+            throw new Exception\ClientIsRateLimitedException;
+          } else {
+            return $request;
+          }
+        }
+      )
+    );
+
+    $stack->push(
+      Middleware::mapResponse(
+        function (ResponseInterface $response) use ($rate_limiter) {
+          if ($response->getStatusCode() == 429) {
+            $rate_limiter->setThrottle($response->getHeader('Retry-After')[0]);
+            throw new Exception\ClientIsRateLimitedException;
+          } else {
+            return $response;
+          }
+        }
+      )
+    );
+
     $defaults = array(
+      'handler' => $stack,
       'base_uri' => self::BASE_URI,
       'connect_timeout' => '3',
       'timeout' => '10',

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -20,14 +20,14 @@ class ApiClient extends Client {
       throw new Exception\MissingClientTokenException;
     }
 
-    $rate_limiter = new RateLimiter();
+    $rateLimiter = new RateLimiter();
     $stack = new HandlerStack();
     $stack->setHandler(new CurlHandler());
 
     $stack->push(
       Middleware::mapRequest(
-        function (RequestInterface $request) use ($rate_limiter) {
-          if ($rate_limiter->isThrottled()) {
+        function (RequestInterface $request) use ($rateLimiter) {
+          if ($rateLimiter->isThrottled()) {
             throw new Exception\ClientIsRateLimitedException;
           } else {
             return $request;
@@ -38,9 +38,9 @@ class ApiClient extends Client {
 
     $stack->push(
       Middleware::mapResponse(
-        function (ResponseInterface $response) use ($rate_limiter) {
+        function (ResponseInterface $response) use ($rateLimiter) {
           if ($response->getStatusCode() == 429) {
-            $rate_limiter->setThrottle($response->getHeader('Retry-After')[0]);
+            $rateLimiter->setThrottle($response->getHeader('Retry-After')[0]);
             throw new Exception\ClientIsRateLimitedException;
           } else {
             return $response;

--- a/src/Exception/ClientIsRateLimitedException.php
+++ b/src/Exception/ClientIsRateLimitedException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Envato\Exception;
+
+class ClientIsRateLimitedException extends \Exception {
+  public function __construct() {
+    parent::__construct('Too many requests');
+  }
+}

--- a/src/Exception/MissingClientTokenException.php
+++ b/src/Exception/MissingClientTokenException.php
@@ -2,6 +2,8 @@
 
 namespace Envato\Exception;
 
-// @codingStandardsIgnoreStart
-class MissingClientTokenException extends \Exception {}
-// @codingStandardsIgnoreEnd
+class MissingClientTokenException extends \Exception {
+  public function __construct() {
+    parent::__construct('Missing required API token.');
+  }
+}

--- a/src/Middleware/RateLimiter.php
+++ b/src/Middleware/RateLimiter.php
@@ -7,7 +7,7 @@ class RateLimiter {
    * @var string Filename of the lock file that is used to hold the unix
    * timestamp of rate limit timeouts.
    */
-  public $rate_limit_file_name = 'envato_api_sdk.lock';
+  public $rateLimitFileName = 'envato_api_sdk.lock';
 
   /**
    * Checks if the client is currently throttled from making requests.
@@ -16,9 +16,9 @@ class RateLimiter {
    * connections.
    */
   public function isThrottled() {
-    $rate_limit_timeout_value = $this->rateLimitTimeoutValue();
+    $rateLimitTimeoutValue = $this->rateLimitTimeoutValue();
 
-    if (time() > $rate_limit_timeout_value) {
+    if (time() > $rateLimitTimeoutValue) {
       $this->removeThrottle();
       return FALSE;
     } else {
@@ -29,18 +29,18 @@ class RateLimiter {
   /**
    * Create a rate limit flag.
    *
-   * @param int $retry_after_value Time in seconds that the client has been rate
+   * @param int $retryAfterValue Time in seconds that the client has been rate
    * limited for.
    */
-  public function setThrottle($retry_after_value) {
-    $retry_after_timestamp = time() + $retry_after_value;
+  public function setThrottle($retryAfterValue) {
+    $retyAfterTimestamp = time() + $retryAfterValue;
 
     if (!$this->temporary_directory_writable()) {
       return FALSE;
     }
 
-    $lock_file = fopen($this->full_system_path_to_lock_file(), 'w');
-    fwrite($lock_file, $retry_after_timestamp);
+    $lock_file = fopen($this->fullSystemPathToLockFile(), 'w');
+    fwrite($lock_file, $retyAfterTimestamp);
     fclose($lock_file);
   }
 
@@ -49,19 +49,19 @@ class RateLimiter {
    *
    * @return string
    */
-  public function full_system_path_to_lock_file() {
-    return sys_get_temp_dir() . '/' . $this->rate_limit_file_name;
+  public function fullSystemPathToLockFile() {
+    return sys_get_temp_dir() . '/' . $this->rateLimitFileName;
   }
 
   /**
    * Clean up throttle flag.
    */
   protected function removeThrottle() {
-    if (!$this->lock_file_is_accessible()) {
+    if (!$this->lockFileIsAccessible()) {
       return FALSE;
     }
 
-    unlink($this->full_system_path_to_lock_file());
+    unlink($this->fullSystemPathToLockFile());
   }
 
   /**
@@ -72,11 +72,11 @@ class RateLimiter {
    * bypassing the rate limiting.
    */
   protected function rateLimitTimeoutValue() {
-    if (!$this->lock_file_is_accessible()) {
+    if (!$this->lockFileIsAccessible()) {
       return 0;
     }
 
-    return (int) file_get_contents($this->full_system_path_to_lock_file());
+    return (int) file_get_contents($this->fullSystemPathToLockFile());
   }
 
   /**
@@ -85,7 +85,7 @@ class RateLimiter {
    * @return boolean
    */
   protected function temporary_directory_writable() {
-    return is_writable(dirname($this->full_system_path_to_lock_file()));
+    return is_writable(dirname($this->fullSystemPathToLockFile()));
   }
 
   /**
@@ -93,7 +93,7 @@ class RateLimiter {
    *
    * @return boolean
    */
-  protected function lock_file_is_accessible() {
-    return (file_exists($this->full_system_path_to_lock_file()) && is_readable($this->full_system_path_to_lock_file()));
+  protected function lockFileIsAccessible() {
+    return (file_exists($this->fullSystemPathToLockFile()) && is_readable($this->fullSystemPathToLockFile()));
   }
 }

--- a/src/Middleware/RateLimiter.php
+++ b/src/Middleware/RateLimiter.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Envato\Middleware;
+
+class RateLimiter {
+  /**
+   * @var string Filename of the lock file that is used to hold the unix
+   * timestamp of rate limit timeouts.
+   */
+  public $rate_limit_file_name = 'envato_api_sdk.lock';
+
+  /**
+   * Checks if the client is currently throttled from making requests.
+   *
+   * @return boolean Whether the client is prohibited from initiating new
+   * connections.
+   */
+  public function isThrottled() {
+    $rate_limit_timeout_value = $this->rateLimitTimeoutValue();
+
+    if (time() > $rate_limit_timeout_value) {
+      $this->removeThrottle();
+      return FALSE;
+    } else {
+      return TRUE;
+    }
+  }
+
+  /**
+   * Create a rate limit flag.
+   *
+   * @param int $retry_after_value Time in seconds that the client has been rate
+   * limited for.
+   */
+  public function setThrottle($retry_after_value) {
+    $retry_after_timestamp = time() + $retry_after_value;
+
+    if (!$this->temporary_directory_writable()) {
+      return FALSE;
+    }
+
+    $lock_file = fopen($this->full_system_path_to_lock_file(), 'w');
+    fwrite($lock_file, $retry_after_timestamp);
+    fclose($lock_file);
+  }
+
+  /**
+   * Defines the full system path to the lock file.
+   *
+   * @return string
+   */
+  public function full_system_path_to_lock_file() {
+    return sys_get_temp_dir() . '/' . $this->rate_limit_file_name;
+  }
+
+  /**
+   * Clean up throttle flag.
+   */
+  protected function removeThrottle() {
+    if (!$this->lock_file_is_accessible()) {
+      return FALSE;
+    }
+
+    unlink($this->full_system_path_to_lock_file());
+  }
+
+  /**
+   * Get the defined rate limit value.
+   *
+   * @return integer Unix timestamp of when the client is able to initiate
+   * requests again. Returns 0 if the lock file isn't accessible as a means of
+   * bypassing the rate limiting.
+   */
+  protected function rateLimitTimeoutValue() {
+    if (!$this->lock_file_is_accessible()) {
+      return 0;
+    }
+
+    return (int) file_get_contents($this->full_system_path_to_lock_file());
+  }
+
+  /**
+   * Check if the system temporary directory is writable.
+   *
+   * @return boolean
+   */
+  protected function temporary_directory_writable() {
+    return is_writable(dirname($this->full_system_path_to_lock_file()));
+  }
+
+  /**
+   * Checks the lock file can be managed by the PHP process.
+   *
+   * @return boolean
+   */
+  protected function lock_file_is_accessible() {
+    return (file_exists($this->full_system_path_to_lock_file()) && is_readable($this->full_system_path_to_lock_file()));
+  }
+}

--- a/src/Response/Account.php
+++ b/src/Response/Account.php
@@ -13,7 +13,7 @@ class Account {
     return $this->data->account->image;
   }
 
-  public function firstname() {
+  public function firstName() {
     return $this->data->account->firstname;
   }
 
@@ -21,11 +21,11 @@ class Account {
     return $this->data->account->surname;
   }
 
-  public function available_earnings() {
+  public function availableEarnings() {
     return $this->data->account->available_earnings;
   }
 
-  public function total_deposits() {
+  public function totalDeposits() {
     return $this->data->account->total_deposits;
   }
 

--- a/src/Response/TotalMarketUsers.php
+++ b/src/Response/TotalMarketUsers.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Envato\Response;
+
+class TotalMarketUsers {
+  protected $data;
+
+  public function __construct($payload) {
+    $this->data = json_decode($payload->getBody()->getContents());
+  }
+
+  public function totalMarketUsers() {
+    return $this->data->{'total-users'}->total_users;
+  }
+}

--- a/src/Response/WhoAmI.php
+++ b/src/Response/WhoAmI.php
@@ -3,6 +3,7 @@
 namespace Envato\Response;
 
 class WhoAmI {
+
   protected $data;
 
   public function __construct($response) {

--- a/tests/Middleware/RateLimiterTest.php
+++ b/tests/Middleware/RateLimiterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Envato\Middleware\RateLimiter;
+use PHPUnit\Framework\TestCase;
+
+final class RateLimiterTest extends TestCase {
+  private $rate_limiter;
+
+  public function setUp() {
+    $this->rate_limiter = new RateLimiter();
+  }
+
+  public function tearDown() {
+    // Don't allow this lock file to be carried between tests.
+    if (file_exists($this->rate_limiter->full_system_path_to_lock_file())) {
+      unlink($this->rate_limiter->full_system_path_to_lock_file());
+    }
+  }
+
+  public function testIsThrottled() {
+    $throttled = $this->rate_limiter->setThrottle(1);
+    $this->assertTrue($this->rate_limiter->isThrottled());
+  }
+
+  public function testThrottlerIsRemovedAfterTimeout() {
+    $throttled = $this->rate_limiter->setThrottle(0);
+    $this->assertFileExists($this->rate_limiter->full_system_path_to_lock_file());
+    sleep(1); // This is bad and needs some time travelling lib
+    $this->assertFalse($this->rate_limiter->isThrottled());
+  }
+
+  public function testThrottleIsOffByDefault() {
+    $this->assertFalse($this->rate_limiter->isThrottled());
+  }
+
+  public function testSettingAThrottler() {
+    $throttled = $this->rate_limiter->setThrottle(1);
+    $this->assertTrue($this->rate_limiter->isThrottled());
+    $this->assertFileExists($this->rate_limiter->full_system_path_to_lock_file());
+  }
+
+  public function testTemporarySystemPathMatches() {
+    $this->assertContains(sys_get_temp_dir(), $this->rate_limiter->full_system_path_to_lock_file());
+    $this->assertContains(
+      $this->rate_limiter->rate_limit_file_name,
+      $this->rate_limiter->full_system_path_to_lock_file()
+    );
+  }
+}

--- a/tests/Middleware/RateLimiterTest.php
+++ b/tests/Middleware/RateLimiterTest.php
@@ -4,46 +4,46 @@ use Envato\Middleware\RateLimiter;
 use PHPUnit\Framework\TestCase;
 
 final class RateLimiterTest extends TestCase {
-  private $rate_limiter;
+  private $rateLimiter;
 
   public function setUp() {
-    $this->rate_limiter = new RateLimiter();
+    $this->rateLimiter = new RateLimiter();
   }
 
   public function tearDown() {
     // Don't allow this lock file to be carried between tests.
-    if (file_exists($this->rate_limiter->full_system_path_to_lock_file())) {
-      unlink($this->rate_limiter->full_system_path_to_lock_file());
+    if (file_exists($this->rateLimiter->fullSystemPathToLockFile())) {
+      unlink($this->rateLimiter->fullSystemPathToLockFile());
     }
   }
 
   public function testIsThrottled() {
-    $throttled = $this->rate_limiter->setThrottle(1);
-    $this->assertTrue($this->rate_limiter->isThrottled());
+    $throttled = $this->rateLimiter->setThrottle(1);
+    $this->assertTrue($this->rateLimiter->isThrottled());
   }
 
   public function testThrottlerIsRemovedAfterTimeout() {
-    $throttled = $this->rate_limiter->setThrottle(0);
-    $this->assertFileExists($this->rate_limiter->full_system_path_to_lock_file());
+    $throttled = $this->rateLimiter->setThrottle(0);
+    $this->assertFileExists($this->rateLimiter->fullSystemPathToLockFile());
     sleep(1); // This is bad and needs some time travelling lib
-    $this->assertFalse($this->rate_limiter->isThrottled());
+    $this->assertFalse($this->rateLimiter->isThrottled());
   }
 
   public function testThrottleIsOffByDefault() {
-    $this->assertFalse($this->rate_limiter->isThrottled());
+    $this->assertFalse($this->rateLimiter->isThrottled());
   }
 
   public function testSettingAThrottler() {
-    $throttled = $this->rate_limiter->setThrottle(1);
-    $this->assertTrue($this->rate_limiter->isThrottled());
-    $this->assertFileExists($this->rate_limiter->full_system_path_to_lock_file());
+    $throttled = $this->rateLimiter->setThrottle(1);
+    $this->assertTrue($this->rateLimiter->isThrottled());
+    $this->assertFileExists($this->rateLimiter->fullSystemPathToLockFile());
   }
 
   public function testTemporarySystemPathMatches() {
-    $this->assertContains(sys_get_temp_dir(), $this->rate_limiter->full_system_path_to_lock_file());
+    $this->assertContains(sys_get_temp_dir(), $this->rateLimiter->fullSystemPathToLockFile());
     $this->assertContains(
-      $this->rate_limiter->rate_limit_file_name,
-      $this->rate_limiter->full_system_path_to_lock_file()
+      $this->rateLimiter->rateLimitFileName,
+      $this->rateLimiter->fullSystemPathToLockFile()
     );
   }
 }


### PR DESCRIPTION
This introduces a new middleware class that is responsible for
gracefully handling when the server presents a HTTP 429 (Too many
requests). This HTTP status is used when a client has reached the
threshold of what has been deemed a suitable threshold by the service
owner and the client should slow their request rate or back off with the
requests.

There are a number of reasons why we would want a piece of middleware
like this.

1. Know when a request is getting rate limited and present that error
   code in a more useful manner that can be identified and tracked.
2. Don't just keep trying the same request over and over again. In some
   of the cases, continuing to request the resource whilst being rate
   limited results in your retry timestamp getting pushed out using
   expotential backoff. This is factored into the class by short
   circuiting the request and not actually sending it if the throttler
   is enabled.

With this in place the client won't continiously attempt to connect to
the server and will eventually succeed without tying up local resources.

Closes #5 